### PR TITLE
making the file command backwards compatible (to at least v4)

### DIFF
--- a/src/main/resources/xld.Folder/unpack_create.sh.ftl
+++ b/src/main/resources/xld.Folder/unpack_create.sh.ftl
@@ -13,7 +13,8 @@
 #!/bin/bash
 set -e
 
-FILE_TYPE=`file -i ${deployed.file.path} | sed -n 's/.*: \(.*\);.*/\1/p'`
+# "file -i -b" output example is "text/plain; charset=us-ascii", so piping into sed to extract only the mime type portion of the output (text/plain)
+FILE_TYPE=`file -i -b ${deployed.file.path} | sed -n 's/\(.*\);.*/\1/p'`
 
 echo "The file type is $FILE_TYPE"
 

--- a/src/main/resources/xld.Folder/unpack_create.sh.ftl
+++ b/src/main/resources/xld.Folder/unpack_create.sh.ftl
@@ -13,7 +13,7 @@
 #!/bin/bash
 set -e
 
-FILE_TYPE=`file --mime-type -b ${deployed.file.path}`
+FILE_TYPE=`file -i ${deployed.file.path} | sed -n 's/.*: \(.*\);.*/\1/p'`
 
 echo "The file type is $FILE_TYPE"
 

--- a/src/main/resources/xld.Folder/unpack_destroy.sh.ftl
+++ b/src/main/resources/xld.Folder/unpack_destroy.sh.ftl
@@ -15,7 +15,8 @@ set -e
 
 echo "Target path is shared? ${previousDeployed.targetPathShared?c}"
 
-FILE_TYPE=`file -i ${previousDeployed.file.path} | sed -n 's/.*: \(.*\);.*/\1/p'`
+# "file -i -b" output example is "text/plain; charset=us-ascii", so piping into sed to extract only the mime type portion of the output (text/plain)
+FILE_TYPE=`file -i -b ${previousDeployed.file.path} | sed -n 's/\(.*\);.*/\1/p'`
 
 echo "The file type is: $FILE_TYPE"
 

--- a/src/main/resources/xld.Folder/unpack_destroy.sh.ftl
+++ b/src/main/resources/xld.Folder/unpack_destroy.sh.ftl
@@ -15,7 +15,7 @@ set -e
 
 echo "Target path is shared? ${previousDeployed.targetPathShared?c}"
 
-FILE_TYPE=`file --mime-type -b ${previousDeployed.file.path}`
+FILE_TYPE=`file -i ${previousDeployed.file.path} | sed -n 's/.*: \(.*\);.*/\1/p'`
 
 echo "The file type is: $FILE_TYPE"
 


### PR DESCRIPTION
Not all of the systems within our organization have the latest version of the file command, so we need to use a variation of the file command that is backwards compatible to v4.